### PR TITLE
Add DTB overlay for MCP7940N connected to I2C2.

### DIFF
--- a/src/arm/BB-I2C2-RTC-MCP7940X.dts
+++ b/src/arm/BB-I2C2-RTC-MCP7940X.dts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2019 Stuart Longland <me@vk4msl.id.au>
+ *
+ * Based on PB-I2C2-RTC-DS1307.dts:
+ * 
+ * Copyright (C) 2018 Tim Small <tim@seoss.co.uk>
+ *
+ * Based on PB-I2C2-RTC-PCF8523.dts:
+ * 
+ * Copyright (C) 2018 Robert Nelson <robertcnelson@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This overlay is for a Microchip MCP7940X RTC connected via the
+ * BeagleBone's second I2C bus.
+ * https://www.microchip.com/wwwproducts/en/MCP79400
+ *
+ * Brisbane WICEN are using this RTC for their RFID field terminals to keep
+ * time whilst the PocketBeagle is powered down to prevent lengthy NTP time
+ * synchronisation sessions over AX.25, but may be useful for others.
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/board/am335x-bbw-bbb-base.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/am33xx.h>
+
+/ {
+	/*
+	 * Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+	 */
+	fragment@0 {
+		target-path="/";
+		__overlay__ {
+
+			chosen {
+				overlays {
+					BB-I2C2-RTC-DS1307 = __TIMESTAMP__;
+				};
+			};
+		};
+	};
+
+	fragment@1 {
+		target-path="/";
+		__overlay__ {
+			aliases {
+				rtc0 = &extrtc;
+				/* The OMAP RTC implementation in the BBB is
+				 * buggy, so that it cannot be used as a
+				 * battery-backed RTS, so that it loses its
+				 * contents when power is removed from the
+				 * Beaglebone...
+				 *
+				 * We move the omap built-in RTC to rtc1, so
+				 * that userspace defaults to using the DS1307.
+				 *
+				 * The omap RTC must remain enabled because it
+				 * is also used during the reboot process on the
+				 * BBB.
+				 */
+				rtc1 = "/ocp/rtc@44e3e000";
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&i2c2>;
+		__overlay__ {
+			status = "okay";
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			extrtc: ds1307@68 {
+				compatible = "microchip,mcp7940x";
+				reg = <0x6f>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
We're using this RTC as it's one of the few available in a DIP-8 form factor and is relatively cheap.  It is "ds1307" compatible, mostly, with the exception of an oscillator start bit in the MSB of the seconds register which must be set to `1` for the clock to tick.

The `rtc-ds1307` driver can be told to do this via device tree, but I haven't figured out how to do it via `sysfs`.  This overlay solves the problem nicely, replacing `rtc0` as well.